### PR TITLE
Add helptext field to template

### DIFF
--- a/resources/js/components/KeyValueFieldForm.vue
+++ b/resources/js/components/KeyValueFieldForm.vue
@@ -1,5 +1,10 @@
 <template>
-  <default-field :field="field" :errors="errors" :full-width-content="true">
+  <default-field
+      :field="field"
+      :errors="errors"
+      :full-width-content="true"
+      :show-help-text="showHelpText"
+  >
     <template slot="field">
       <KeyValueTable
         :edit-mode="!field.readonly"


### PR DESCRIPTION
I noticed, that the helptext is not shown. I added it to the template. I tried re-building the JS but could not get it to work. Hopefully you don't mind re-building it with the helptext in the template. Thx.